### PR TITLE
Fix handling of namespaced Shiny sessions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # connectcreds (development version)
 
+* `connect_viewer_token()` and `has_viewer_token()` can now be used inside Shiny
+  modules (#6).
+
 # connectcreds 0.2.0
 
 * New `connect_service_account_token()` and `has_service_account_token()`

--- a/R/viewer-based-credentials.R
+++ b/R/viewer-based-credentials.R
@@ -194,7 +194,7 @@ check_shiny_session <- function(
   arg = caller_arg(x),
   call = caller_env()
 ) {
-  if (!missing(x) && inherits(x, "ShinySession")) {
+  if (!missing(x) && inherits(x, c("ShinySession", "session_proxy"))) {
     return(invisible(x))
   }
   stop_input_type(


### PR DESCRIPTION
Previously we looked only for the root session, but this should allow `connect_viewer_token()` to be used inside of Shiny modules, too.

Closes #6.